### PR TITLE
Fix updateNode being called with undefined rootNode

### DIFF
--- a/src/-private/create-store.ts
+++ b/src/-private/create-store.ts
@@ -31,20 +31,23 @@ export default function createStore<S, A extends Action, Ext, StateExt>(
   );
 
   const originalGetState = store.getState.bind(store);
-
-  let rootNode;
-
-  store.getState = (): S => {
+  const ensureRootNode = (): void => {
     if (rootNode === undefined) {
       rootNode = createNode({
         state: originalGetState(),
       });
     }
+  }
 
+  let rootNode;
+
+  store.getState = (): S => {
+    ensureRootNode();
     return rootNode.proxy.state;
   };
 
   store.subscribe(() => {
+    ensureRootNode();
     updateNode(rootNode, {
       state: originalGetState(),
     });

--- a/tests/unit/basic-test.js
+++ b/tests/unit/basic-test.js
@@ -25,7 +25,15 @@ function createCache(fn) {
 
 module('Unit | basic', () => {
   module('primitive root', () => {
-    test('it works', (assert) => {
+    test('redux works', (assert) => {
+      let store = createStore((state = 0) => ++state);
+
+      store.dispatch({ type: 'INCREMENT' });
+
+      assert.equal(store.getState(), 2, 'value is correct');
+    });
+
+    test('caching works', (assert) => {
       let store = createStore((state = 0) => ++state);
 
       let cache = createCache(() => store.getState());


### PR DESCRIPTION
When redux `dispatch()` is called before `getState()` has ever been called, `updateNode()` (in the custom `creatStore()` function) will be called with `rootNode` still undefined.

This wasn't catched in tests as they coincidentally always called `getState()` (for the cache setup) before dispatching. The added test here reproduces the bug that I was seeing when that's not the case.